### PR TITLE
adding forgetRecaller for logout

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -178,6 +178,16 @@ class Guard {
 	}
 
 	/**
+	 * Remove a remember me cookie
+	 *
+	 * @return Symfony\Component\HttpFoundation\Cookie
+	 */
+	protected function forgetRecaller()
+	{
+		return $this->getCookieJar()->forget($this->getRecallerName());
+	}
+
+	/**
 	 * Log the user out of the application.
 	 *
 	 * @return void
@@ -185,6 +195,8 @@ class Guard {
 	public function logout()
 	{
 		$this->session->forget($this->getName());
+		
+		$this->queuedCookies[] = $this->forgetRecaller();
 
 		$this->user = null;
 	}

--- a/tests/GuardTest.php
+++ b/tests/GuardTest.php
@@ -105,6 +105,7 @@ class GuardTest extends PHPUnit_Framework_TestCase {
 	{
 		list($session, $provider, $request, $cookie) = $this->getMocks();
 		$mock = $this->getMock('Illuminate\Auth\Guard', array('getName'), array($provider, $session, $request));
+		$mock->setCookieJar($cookies = m::mock('Illuminate\CookieJar'));
 		$user = m::mock('Illuminate\Auth\UserInterface');
 		$mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
 		$mock->getSession()->shouldReceive('forget')->once()->with('foo');


### PR DESCRIPTION
Using the auth with a "remember me" seems to disable the "logout" from actually logging out the user. This should take care of it.
