### PR TITLE
Fix: CSS/JS for make:auth views didn't work with MAMP

### DIFF
--- a/Console/stubs/make/views/layouts/app.stub
+++ b/Console/stubs/make/views/layouts/app.stub
@@ -11,7 +11,7 @@
     <title>{{ config('app.name', 'Laravel') }}</title>
 
     <!-- Styles -->
-    <link href="/css/app.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ URL::asset('css/app.css') }}">
 
     <!-- Scripts -->
     <script>
@@ -82,6 +82,6 @@
     </div>
 
     <!-- Scripts -->
-    <script src="/js/app.js"></script>
+    <script src="{{ URL::asset('/js/app.js') }}">
 </body>
 </html>


### PR DESCRIPTION
This issue occurred on Mac OS Sierra. The app.css and app.js weren't able to be found when the app was run with MAMP, but were able to able to be found when running "php artisan serve" in the command line. This makes it able for both to be found.