### PR TITLE
Add email/verify route exception for note redirect

### DIFF
--- a/Middleware/EnsureEmailIsVerified.php
+++ b/Middleware/EnsureEmailIsVerified.php
@@ -19,7 +19,8 @@ class EnsureEmailIsVerified
     {
         if (! $request->user() ||
             ($request->user() instanceof MustVerifyEmail &&
-            ! $request->user()->hasVerifiedEmail())) {
+            ! $request->user()->hasVerifiedEmail() &&
+            $request->route()->uri != 'email/verify')) {
             return $request->expectsJson()
                     ? abort(403, 'Your email address is not verified.')
                     : Redirect::route('verification.notice');


### PR DESCRIPTION
When add this middleware "`\Illuminate\Auth\Middleware\EnsureEmailIsVerified::class`" to `$middlewareGroups['web']`, Laravel entering the many redirects loop.

When unverified user visit the `/home` page, Laravel redirect to `/email/verify` page and `/email/verify` page again redirect to `/email/verify` page.

I'm fix this.