### PR TITLE
Add the password reset URL to the toMailCallback

### DIFF
--- a/Notifications/ResetPassword.php
+++ b/Notifications/ResetPassword.php
@@ -59,20 +59,31 @@ class ResetPassword extends Notification
      */
     public function toMail($notifiable)
     {
+        $url = $this->resetUrl($notifiable);
+
         if (static::$toMailCallback) {
-            return call_user_func(static::$toMailCallback, $notifiable, $this->token);
+            return call_user_func(static::$toMailCallback, $notifiable, $this->token, $url);
         }
 
+        return $this->buildMailMessage($url);
+    }
+    
+    /**
+     * Get the reset URL for the given notifiable.
+     *
+     * @param  mixed  $notifiable
+     * @return string
+     */
+    protected function resetUrl($notifiable)
+    {
         if (static::$createUrlCallback) {
-            $url = call_user_func(static::$createUrlCallback, $notifiable, $this->token);
+            return call_user_func(static::$createUrlCallback, $notifiable, $this->token);
         } else {
-            $url = url(route('password.reset', [
+            return url(route('password.reset', [
                 'token' => $this->token,
                 'email' => $notifiable->getEmailForPasswordReset(),
             ], false));
         }
-
-        return $this->buildMailMessage($url);
     }
 
     /**


### PR DESCRIPTION
It is useful to receive the generated reset URL in the callback, because if we want to only change the mail template texts (`ResetPassword::toMailUsing(function($user, $token) {}`) we have to generate it ourselves.

Backwards compatibility is kept, as it is a new parameter.