### PR TITLE
RequestGuard::setRequest() should reset $this->user

### DIFF
--- a/RequestGuard.php
+++ b/RequestGuard.php
@@ -80,6 +80,7 @@ class RequestGuard implements Guard
     public function setRequest(Request $request)
     {
         $this->request = $request;
+        $this->user = null;
 
         return $this;
     }


### PR DESCRIPTION
`RequestGuard::user()` uses `$this->user` as a cache to avoid computing the current user again for a given request. However, when rebinding the current request, `$this->user` is not reset so the previous request’s value will still be used, even though different requests can of course come from different users.

I’ve stumbled onto this in the context of PHPUnit tests, where there can of course easily be several requests with different authentication inside a single PHP process. This caused my tests to fail, but I think this is an underlying logical problem in this package, not something I should just work around in my testing code.

Sorry if I got this completely wrong, I haven’t worked with the Laravel/Lumen internals much yet.

System:
- Laravel Lumen 9.1.6
- `illuminate/auth` 9.52.16
- PHP 8.2.13